### PR TITLE
Перед каждым запуском бенчмарка дергать taskset

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation("net.java.dev.jna:jna:5.12.1")
     testImplementation("org.jetbrains.kotlinx:lincheck:2.16")
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
+    implementation("com.github.oshi:oshi-dist:6.4.0")
 }
 
 tasks.test {

--- a/src/main/java/ru/ricnorr/benchmarks/BenchmarkRunner.java
+++ b/src/main/java/ru/ricnorr/benchmarks/BenchmarkRunner.java
@@ -53,7 +53,6 @@ public class BenchmarkRunner {
         Runnable actionWithoutLock
     ) {
         List<IterationResult> iterationsResults = new ArrayList<>();
-        System.out.println("Run iterations");
         for (int i = 0; i < iterations; i++) {
             System.out.println("Run iteration " + i);
             long withLockNanos = measureDurationForActionNanos(threads, actionsPerThread, actionWithLock);
@@ -64,7 +63,6 @@ public class BenchmarkRunner {
             iterationsResults.add(new IterationResult(threads, overheadNanos, throughputNanos));
             System.out.println("End iteration " + i);
         }
-        System.out.println("Benchmark completed");
 
         return new BenchmarkResult(iterationsResults.stream().mapToDouble(it -> it.overheadNanos).summaryStatistics().getAverage(),
                 iterationsResults.stream().mapToDouble(it -> it.throughputNanos).summaryStatistics().getAverage());


### PR DESCRIPTION
getProcessorsNumbersInNumaNodeOrder() - получает информацию о всех процессорах, и сортирует их в порядке нума сокетов. Таким образом, мы всегда стараемся запустить на как можно меньшем кол-ве нума нод.